### PR TITLE
Fix tokenizer training error

### DIFF
--- a/tinystories.py
+++ b/tinystories.py
@@ -57,7 +57,7 @@ def make_instruction(example: dict) -> dict:
     }
 
 
-def make_text(example: dict, instruction_subset: set) -> str:
+def make_text(example: dict, instruction_subset: set = None) -> str:
     instructions = make_instruction(example)
     if instruction_subset:
         instructions = {k: v for k, v in instructions.items() if k in instruction_subset}


### PR DESCRIPTION
When generating data for tokenizer training, we use "make_text" function without "instruction_subset" argument. 

This fixes the bug where the argument was non-optional.